### PR TITLE
debugpy 1.8.16 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,6 @@ build:
   entry_points:
     - debugpy = debugpy.server.cli:main
     - debugpy-adapter = debugpy.adapter.__main__:main
-  ignore_run_exports:
-    - libcxx  # [osx]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "debugpy" %}
-{% set version = "1.8.11" %}
+{% set version = "1.8.16" %}
 
 package:
   name: {{ name|lower }}
@@ -7,18 +7,21 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6ad2688b69235c43b020e04fecccdf6a96c8943ca9c2fb340b8adc103c655e57
+  sha256: 31e69a1feb1cf6b51efbed3f6c9b0ef03bc46ff050679c4be7ea6d2e23540870
 
 build:
   number: 0
   entry_points:
     - debugpy = debugpy.server.cli:main
+  ignore_run_exports:
+    - libcxx  # [osx]
 
 requirements:
   build:
     - python
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}           # [unix]
+    - {{ compiler('cxx') }}         # [unix]
+    - pkg-config                    # [linux]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,17 @@ build:
   number: 0
   entry_points:
     - debugpy = debugpy.server.cli:main
+    - debugpy-adapter = debugpy.adapter.__main__:main
   ignore_run_exports:
     - libcxx  # [osx]
 
 requirements:
   build:
     - python
-    - {{ compiler('c') }}           # [unix]
-    - {{ compiler('cxx') }}         # [unix]
-    - pkg-config                    # [linux]
+    - {{ stdlib('c') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - pkg-config
   host:
     - python
     - pip
@@ -31,16 +33,17 @@ requirements:
     - python
 
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
   imports:
     - debugpy
     - debugpy.adapter
     - debugpy.common
     - debugpy.launcher
     - debugpy.server
+  requires:
+    - pip
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://github.com/Microsoft/debugpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,12 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 31e69a1feb1cf6b51efbed3f6c9b0ef03bc46ff050679c4be7ea6d2e23540870
+  - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 31e69a1feb1cf6b51efbed3f6c9b0ef03bc46ff050679c4be7ea6d2e23540870
+
+  - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: cce9b8aeed25f8ba33df464283112a87a7881e5d3b5dc3c9f30dc9852ec123db
+    folder: gh_src
 
 build:
   number: 0
@@ -30,7 +34,16 @@ requirements:
   run:
     - python
 
+{% set SKIP_TEST_FILES = [
+    "gh_src/tests/debugpy/test_flask.py",
+    "gh_src/tests/debugpy/test_django.py",
+    "gh_src/tests/debugpy/test_gevent.py",
+    "gh_src/tests/debugpy/test_numpy.py"
+] %}
+
 test:
+  source_files:
+    - gh_src/tests
   imports:
     - debugpy
     - debugpy.adapter
@@ -39,9 +52,15 @@ test:
     - debugpy.server
   requires:
     - pip
+    - pytest
+    - pytest-xdist
+    - pytest-timeout
+    - psutil
+    - requests
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - python -m pytest -n auto --dist=loadfile --timeout=180 --timeout-method=thread --durations=25 -o pythonpath=gh_src gh_src/tests/debugpy -v {% for file in SKIP_TEST_FILES %} --ignore={{ file }}{% endfor %}
 
 about:
   home: https://github.com/Microsoft/debugpy


### PR DESCRIPTION
debugpy 1.8.16 

**Destination channel:** Defaults

### Links

- [PKG-9283]
- dev_url:        https://github.com/microsoft/debugpy/tree/v1.8.16
- conda_forge:    https://github.com/conda-forge/debugpy-feedstock
- pypi:           https://pypi.org/project/debugpy/1.8.16
- pypi inspector: https://inspector.pypi.io/project/debugpy/1.8.16

### Explanation of changes:

- new version number


[PKG-9283]: https://anaconda.atlassian.net/browse/PKG-9283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ