### PR TITLE
debugpy 1.8.21 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,24 @@
 {% set name = "debugpy" %}
-{% set version = "1.8.16" %}
+{% set version = "1.8.21" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 31e69a1feb1cf6b51efbed3f6c9b0ef03bc46ff050679c4be7ea6d2e23540870
+    sha256: a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6
 
   - url: https://github.com/microsoft/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: cce9b8aeed25f8ba33df464283112a87a7881e5d3b5dc3c9f30dc9852ec123db
+    sha256: 5f1699a85d124efded8b64b6ecff6060e1d53bf652436061e59b8a2201e15c6c
     folder: gh_src
 
 build:
-  number: 1
+  number: 0
   entry_points:
     - debugpy = debugpy.server.cli:main
     - debugpy-adapter = debugpy.adapter.__main__:main
+  skip: true # [py<38]
 
 requirements:
   build:


### PR DESCRIPTION
debugpy 1.8.21 

**Destination channel:** Defaults

### Links

- [PKG-15819]
- dev_url:        https://github.com/microsoft/debugpy/tree/v1.8.21
- conda_forge:    https://github.com/conda-forge/debugpy-feedstock
- pypi:           https://pypi.org/project/debugpy/1.8.21
- pypi inspector: https://inspector.pypi.io/project/debugpy/1.8.21

### Explanation of changes:

- new version number


[PKG-15819]: https://anaconda.atlassian.net/browse/PKG-15819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ